### PR TITLE
CI: Restrict concurrent E2E workflows

### DIFF
--- a/.github/workflows/run-e2e.yaml
+++ b/.github/workflows/run-e2e.yaml
@@ -5,6 +5,8 @@ on:
       - main
   pull_request:
 
+concurrency: e2e
+
 jobs:
   e2e:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Detailed description**:
* Ensure only one `e2e` workflow will run at a time.

**Which issue(s) this PR fixes**:
Fixes #None

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

